### PR TITLE
Ignore non-objects in camelizeAllKeys

### DIFF
--- a/dist/transform-object.esm.js
+++ b/dist/transform-object.esm.js
@@ -106,6 +106,7 @@ var snakify = function snakify(str) {
 
 
 var camelizeAllKeys = curry1(function (obj) {
+  if (obj === null || _typeof(obj) !== 'object') return obj;
   return Object.keys(obj).reduce(function (acc, key) {
     return assoc(camelize(key), obj[key], acc);
   }, {});
@@ -171,6 +172,7 @@ var camelizeKeysDeep = curry2(function (keysToCamelize, obj) {
  */
 
 var snakifyAllKeys = curry1(function (obj) {
+  if (obj === null || _typeof(obj) !== 'object') return obj;
   return Object.keys(obj).reduce(function (acc, key) {
     return assoc(snakify(key), obj[key], acc);
   }, {});

--- a/dist/transform-object.umd.js
+++ b/dist/transform-object.umd.js
@@ -112,6 +112,7 @@
 
 
   var camelizeAllKeys = curry1(function (obj) {
+    if (obj === null || _typeof(obj) !== 'object') return obj;
     return Object.keys(obj).reduce(function (acc, key) {
       return assoc(camelize(key), obj[key], acc);
     }, {});
@@ -177,6 +178,7 @@
    */
 
   var snakifyAllKeys = curry1(function (obj) {
+    if (obj === null || _typeof(obj) !== 'object') return obj;
     return Object.keys(obj).reduce(function (acc, key) {
       return assoc(snakify(key), obj[key], acc);
     }, {});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test": "mocha",
+    "pretest": "npm run format",
     "build": "rollup -c",
     "lint": "eslint --cache . && prettier --list-different '**/*.js'",
     "format": "prettier --write --loglevel=warn '**/*.js' && eslint --cache --fix ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salemove/transform-object",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "module": "dist/transform-object.esm.js",
   "browser": "dist/transform-object.umd.js",

--- a/src/transform-object.js
+++ b/src/transform-object.js
@@ -50,9 +50,11 @@ const snakify = str =>
  *   camelizeAllKeys({target_user: {target_name: 'John'}});
  *     // => {targetUser: {target_name: 'John'}}
  */
-export const camelizeAllKeys = curry1(obj =>
-  Object.keys(obj).reduce((acc, key) => assoc(camelize(key), obj[key], acc), {})
-);
+export const camelizeAllKeys = curry1(obj => {
+  if (obj === null || typeof obj !== 'object') return obj;
+
+  return Object.keys(obj).reduce((acc, key) => assoc(camelize(key), obj[key], acc), {});
+});
 
 /**
  * Creates a new object with all the keys changed to camelcase.
@@ -111,9 +113,11 @@ export const camelizeKeysDeep = curry2((keysToCamelize, obj) =>
  *   snakifyAllKeys({targetUser: {targetName: 'John'}});
  *     // => {target_user: {targetName: 'John'}}
  */
-export const snakifyAllKeys = curry1(obj =>
-  Object.keys(obj).reduce((acc, key) => assoc(snakify(key), obj[key], acc), {})
-);
+export const snakifyAllKeys = curry1(obj => {
+  if (obj === null || typeof obj !== 'object') return obj;
+
+  return Object.keys(obj).reduce((acc, key) => assoc(snakify(key), obj[key], acc), {});
+});
 
 /**
  * Creates a new object with all the keys changed to snakecase.

--- a/test/camelizeAllKeys.test.js
+++ b/test/camelizeAllKeys.test.js
@@ -21,4 +21,16 @@ describe('camelizeAllKeys', () => {
 
     expect(camelizeAllKeys(obj)).to.eql(expectedResponse);
   });
+
+  it('ignores null', () => {
+    expect(camelizeAllKeys(null)).to.eql(null);
+  });
+
+  it('ignores undefined', () => {
+    expect(camelizeAllKeys(undefined)).to.eql(undefined);
+  });
+
+  it('ignores string', () => {
+    expect(camelizeAllKeys('some')).to.eql('some');
+  });
 });

--- a/test/snakifyAllKeys.test.js
+++ b/test/snakifyAllKeys.test.js
@@ -21,4 +21,16 @@ describe('snakifyAllKeys', () => {
 
     expect(snakifyAllKeys(obj)).to.eql(expectedResponse);
   });
+
+  it('ignores null', () => {
+    expect(snakifyAllKeys(null)).to.eql(null);
+  });
+
+  it('ignores undefined', () => {
+    expect(snakifyAllKeys(undefined)).to.eql(undefined);
+  });
+
+  it('ignores string', () => {
+    expect(snakifyAllKeys('some')).to.eql('some');
+  });
 });

--- a/test/snakifyKeysDeep.test.js
+++ b/test/snakifyKeysDeep.test.js
@@ -10,10 +10,12 @@ describe('snakifyKeysDeep', () => {
   });
 
   it('renames nested keys', () => {
-    expect(snakifyKeysDeep(['targetUser'], {targetUser: {targetName: 'John'}, userAge: 21})).to.eql({
-      target_user: {target_name: 'John'},
-      userAge: 21
-    });
+    expect(snakifyKeysDeep(['targetUser'], {targetUser: {targetName: 'John'}, userAge: 21})).to.eql(
+      {
+        target_user: {target_name: 'John'},
+        userAge: 21
+      }
+    );
   });
 
   it('does not camelizes not listed keys and their children', () => {


### PR DESCRIPTION
This simplifies usage of `camelizeAllKeys`. Without the check, an error
of `Cannot convert undefined or null to object` is thrown when null
is passed to it.