### PR TITLE
Set publish config to GitHub Packages registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "author": "Glia TechMovers",
   "license": "MIT",
   "prettier": "@salemove/prettier-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salemove/transform-object.git"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "browserslist": {
     "ie": ">= 11",
     "chrome": "last 5 versions",


### PR DESCRIPTION
In order to start using our private registry in backend-web
we need to re-publish the current npm packages to our private
registry in GitHub. The reason for this is they share the same
namespace (@salemove) and not doing it would cause a conflict
between the two registries.

BROW-1041
